### PR TITLE
Added code formatting to thymeleaf HTML block

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,9 @@ public class ExampleResource {
 }
 
 ```
-#template
+
+#Template
+
 default location:
 classpath:/templates/something.html<br/>
     [/template/] is libraly default prefix. you can change default prefix by  ThymeleafViewRenderer's constructor. 


### PR DESCRIPTION
I thought it was a bit hard to read the example in the README and the syntax highlighting rules for HTML seem to work well with Thymeleaf templates so I changed it accordingly.
